### PR TITLE
Fix sip dir on arch linux (/usr/share/sip/PyQt4/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__
 /pygs/
 !/pygs/sip/
 !/pygs/configure.py
+
+/build/
+*.egg-info

--- a/pygs/configure.py
+++ b/pygs/configure.py
@@ -31,12 +31,14 @@ except ImportError:
 
     class Configuration(sipconfig.Configuration):
         def __init__(self):
-            try:
-                import PyQt5 as PyQt
-                from PyQt5 import QtCore
-            except ImportError:
+            if os.environ['QT_API'] == 'pyqt4':
                 import PyQt4 as PyQt
                 from PyQt4 import QtCore
+            else:
+                import PyQt5 as PyQt
+                from PyQt5 import QtCore
+
+            print('building for %s' % PyQt.__name__)
 
             qmake_props = subprocess.check_output(["qmake", "-query"], universal_newlines=True)
             qmake_props = dict(x.split(":", 1) for x in qmake_props.splitlines())
@@ -50,6 +52,10 @@ except ImportError:
             cfg['pyqt_mod_dir'] = cfg['pyqt_bin_dir']
             cfg['pyqt_modules'] = "QtCore QtGui"  # FIXME
             cfg['pyqt_sip_dir'] = os.path.join(cfg['pyqt_mod_dir'], "sip", PyQt.__name__)
+            if not os.path.exists(os.path.join(cfg['pyqt_sip_dir'],
+                    'QtCoremod.sip')):
+                cfg['pyqt_sip_dir'] = os.path.join(
+                        sys.prefix, 'share', 'sip', PyQt.__name__)
             cfg['pyqt_sip_flags'] = QtCore.PYQT_CONFIGURATION['sip_flags']
             cfg['pyqt_version'] = QtCore.PYQT_VERSION
             cfg['pyqt_version_str'] = QtCore.PYQT_VERSION_STR

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ from setuptools import setup, Extension
 from setuptools.command.bdist_egg import NATIVE_EXTENSIONS
 
 
+os.environ.setdefault('QT_API', 'pyqt5')
+
+
 def makedirs(name):
     if not os.path.exists(name):
         os.makedirs(name)


### PR DESCRIPTION
This PR fix a configuration issue when installing **pygs** on **ArchLinux**. The issue is that the sip files are not located under the PyQt directory but under `/usr/share/sip/PyQt4/`. The fix is to look for QtCoremode.sip under the PyQt directory and to adapt the `pyqt_sip_dir` to `/usr/share/sip/PyQt4` if the sip file could not be found.

I've also added a way to specify the target qt_api. The issue is that if you have both PyQt5 and PyQt4 installed on your system, pygs/configure.py will automatically pick up PyQt5. Now it will read the `QT_API` environment variable (which is set to `pyqt5` by default) to import the correct API.
