### PR TITLE
Add a small test suite + continuous integration on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__
 !/pygs/configure.py
 /build/
 *.egg-info
+/.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+env:
+  # We only test interpreters who have native pyqt packages
+  # Since travis is still running Ubuntu 12.04, pyqt5 cannot be tested yet
+  - TOXENV=py27-pyqt4
+  - TOXENV=py32-pyqt4
+matrix:
+    exclude:
+        # exclude redundant environments
+        - python: "2.7"
+          env: TOXENV=py32-pyqt4
+        - python: "3.2"
+          env: TOXENV=py27-pyqt4
+virtualenv:
+  system_site_packages: true
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+install:
+  - sudo apt-get install -qq python-qt4 python-qt4-dev python-sip python-sip-dev --fix-missing
+  - sudo apt-get install -qq python3-pyqt4 python3-sip python3-sip-dev --fix-missing
+  - pip install --quiet tox;
+script:
+  - tox;

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,8 @@ or
 
 ``setup.py install``
 
-(Target Qt binding version can be specified by environment variable ``QT_APT``, valid values is ``PyQt4`` or ``PyQt5``.)
+(Target Qt binding version can be specified by environment variable
+``QT_SELECT``, valid values are ``4`` or ``5``.)
 
 Install from Binary Package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,3 +104,34 @@ pygs  - Python bindings to libqxt's QxtGlobalShortcut using SIP and PyQt. In oth
 You may use pygs under the terms of the General Public License (GPL) Version 3 or you may contact the author for permission or a commercial license. The commercial license option is specifically provided for those who are unable or unwilling to use the GPL.
 
 http://www.gnu.org/licenses/gpl-3.0.txt
+
+Testing
+-------
+
+There is a minimal test suite that check the compilation process for various
+environments and ensure QxtGlobalShortcut can be properly imported and used.
+
+To run the tests, you must first install tox::
+
+    $ pip install tox
+
+
+Then you can run the tests by running the following command::
+
+    $ tox
+
+To run the tests against a specific environment, use the -e option. E.g. to run
+tests with python 2.7 and pyqt4, you would run::
+
+    $ tox -e py27-pyqt4
+
+Here is the list of available test environments:
+
+- py27-pyqt4
+- py27-pyqt5
+- py32-pyqt4
+- py32-pyqt5
+- py33-pyqt4
+- py33-pyqt5
+- py34-pyqt4
+- py34-pyqt5

--- a/pygs/configure.py
+++ b/pygs/configure.py
@@ -24,9 +24,9 @@ if not newer_group(sources, build_file):
     sys.exit(0)
 
 
-qt_api = os.environ.get('QT_API', '').lower()
+qt_api = os.environ.get('QT_SELECT', '').lower()
 try:
-    if qt_api and qt_api != 'pyqt4':
+    if qt_api and qt_api != '4':
         raise ImportError()
     from PyQt4.pyqtconfig import Configuration
 except ImportError:
@@ -35,9 +35,9 @@ except ImportError:
 
     class Configuration(sipconfig.Configuration):
         def __init__(self):
-            if qt_api == 'pyqt4':
+            if qt_api == '4':
                 import PyQt4 as PyQt
-            elif qt_api == 'pyqt5':
+            elif qt_api == '5':
                 import PyQt5 as PyQt
             else:
                 try:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+norecursedirs = .tox pygs examples
+;addopts=--capture=no

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+
+try:
+    if os.environ['QT_SELECT'] == '4':
+        from PyQt4.QtCore import QTimer
+        from PyQt4.QtGui import QApplication, QKeySequence, QWidget
+        from PyQt4.QtTest import QTest
+    else:
+        from PyQt5.QtCore import QTimer
+        from PyQt5.QtWidgets import QApplication, QWidget
+        from PyQt5.QtGui import QKeySequence
+        from PyQt5.QtTest import QTest
+except ImportError:
+    pass
+else:
+    from pygs import QxtGlobalShortcut
+
+    def test_functional():
+        app = QApplication(sys.argv)
+        widget = QWidget()
+        widget.show()
+        shortcut = QxtGlobalShortcut()
+        shortcut.setShortcut(QKeySequence('Ctrl+Alt+E'))
+        shortcut.activated.connect(app.exit)
+        QTimer.singleShot(100, shortcut.activated.emit)
+        app.exec_()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,33 @@
+[testenv]
+deps =
+    pytest
+    # coloroma for colored debug output
+    colorama
+commands =
+    py.test {posargs}
+# allow sitepackages because PyQt cannot be installed by pip in a virtualenv
+sitepackages = True
+[testenv:py27-pyqt4]
+basepython=python2.7
+setenv = QT_SELECT=4
+[testenv:py27-pyqt5]
+basepython=python2.7
+setenv = QT_SELECT=5
+[testenv:py32-pyqt4]
+basepython=python3.2
+setenv = QT_SELECT=4
+[testenv:py32-pyqt5]
+basepython=python3.2
+setenv = QT_SELECT=5
+[testenv:py33-pyqt4]
+basepython=python3.3
+setenv = QT_SELECT=4
+[testenv:py33-pyqt5]
+basepython=python3.3
+setenv = QT_SELECT=5
+[testenv:py34-pyqt4]
+basepython=python3.4
+setenv = QT_SELECT=4
+[testenv:py34-pyqt5]
+basepython=python3.4
+setenv = QT_SELECT=5


### PR DESCRIPTION
The test suite is minimal, we just check if the project compiles fine and if we are able to import pygs.QxtGlobalShortcut without any error. Everything is explained in the [readme](https://github.com/ColinDuquesnoy/pygs/tree/test_suite#testing) :wink: 

PyQt5 is not tested on travis because travis is still running Ubuntu 12.04 which does not have any native packages for PyQt5.

To enable CI integration you must register on Travis CI and enable your repo. Tests will run the first time you push so I suggest you to register before merging the PR. Here is how it looks for in my fork: https://travis-ci.org/ColinDuquesnoy/pygs

I also changed `QT_API` to `QT_SELECT` so that we can specify both the pyqt api and the qmake executable using only one environment variable (#5) . I adapted the readme consequently.
